### PR TITLE
map nodes to muts

### DIFF
--- a/ld_graph/cli.py
+++ b/ld_graph/cli.py
@@ -2,6 +2,7 @@
 Command line interface for ld_graph.
 """
 import argparse
+import csv
 import sys
 import networkx as nx
 import logging
@@ -54,8 +55,8 @@ def ld_graph_cli_parser():
     )
     parser.add_argument(
         "output",
-        help="The path and name of output file where the \
-                        SNP graphical model will be stored.",
+        help="The path and name of output file, without an extension, which will store the \
+                SNP graphical model and dictionary mapping graph nodes to mutation ids.",
     )
     # parser.add_argument(
     #    "-p", "--progress", action="store_true", help="Show progress bar."
@@ -73,10 +74,14 @@ def run_reduce(args):
         ts = tskit.load(args.tree_sequence)
     except tskit.FileFormatError as ffe:
         error_exit(f"Error loading '{args.tree_sequence}: {ffe}")
-    snp_graph = ld_graph.reduce(
+    snp_graph, id_to_muts = ld_graph.reduce(
         ts,
     )
-    nx.readwrite.edgelist.write_edgelist(snp_graph, args.output)
+    nx.readwrite.edgelist.write_edgelist(snp_graph, args.output + ".txt")
+    with open(args.output + ".csv", "w") as csv_file:
+        writer = csv.writer(csv_file)
+        for key, value in id_to_muts.items():
+            writer.writerow([key, value])
 
 
 def ld_graph_main(arg_list=None):

--- a/ld_graph/core.py
+++ b/ld_graph/core.py
@@ -29,12 +29,12 @@ def reduce_graph(brick_graph, brick_ts):
     Make a reduced graph from a brick graph and bricked tree sequence
     """
     snp_grapher = snp_graph.SNP_Graph(brick_graph, brick_ts)
-    reduced_graph = snp_grapher.create_reduced_graph()
-    return reduced_graph
+    reduced_graph, id_to_muts = snp_grapher.create_reduced_graph()
+    return reduced_graph, id_to_muts
 
 
 def reduce(ts):
     bricked = brick_ts(ts)
     bricked_graph = brick_graph(bricked)
-    reduced_graph = reduce_graph(bricked_graph, bricked)
-    return reduced_graph
+    reduced_graph, id_to_muts = reduce_graph(bricked_graph, bricked)
+    return reduced_graph, id_to_muts


### PR DESCRIPTION
Multiple mutations can occur on a brick, so we need to have a mapping of node ids in the final reduced graph to mutations. This is accomplished by returning a dictionary where keys are node ids in the graph and values refer to mutations.