### PR TITLE
Add kwargs to frequency_regularize

### DIFF
--- a/ld_graph/core.py
+++ b/ld_graph/core.py
@@ -23,11 +23,11 @@ def time_regularize(ts, time):
     return regularization.Regularize(ts).time_regularize(time)
 
 
-def frequency_regularize(ts, freq):
+def frequency_regularize(ts, freq, **kwargs):
     """
     Regularize a tree sequence by frequency
     """
-    return regularization.Regularize(ts).frequency_regularize(freq)
+    return regularization.Regularize(ts).frequency_regularize(freq, **kwargs)
 
 
 def brick_graph(brick_ts, use_rule_two=True):

--- a/ld_graph/regularization.py
+++ b/ld_graph/regularization.py
@@ -44,7 +44,22 @@ class Regularize:
         tables.simplify(samples)
         return tables.tree_sequence()
 
-    def frequency_regularize(self, frequency):
+    def frequency_regularize(self, frequency, **kwargs):
+        """
+        Takes a tree sequence and removes nodes which are less than the given frequency.
+
+        :param TreeSequence tree_sequence: The input :class:`tskit.TreeSequence` to be
+            regularized.
+        :param float frequency: The maximum frequency of nodes to be retained in the tree
+            sequence. All nodes with frequency less than or equal to `frequency` will
+            be removed from the tree sequence.
+        :param \\**kwargs: All further keyword arguments are passed to
+            ``tskit.simplify``. The keyword argument `samples` cannot be passed.
+        :return: A tree sequence regularized by removing nodes based on their frequency.
+        :rtype: tskit.TreeSequence
+        """
+        if "samples" in kwargs:
+            raise ValueError("Cannot pass 'samples' to simplify()")
         edges = np.array(
             [
                 (parent, child)
@@ -77,7 +92,7 @@ class Regularize:
             time=self.ts.tables.nodes.time,
         )
         all_samples_ts = tables.tree_sequence()
-        pruned_ts = all_samples_ts.simplify(samples=keep_nodes)
+        pruned_ts = all_samples_ts.simplify(samples=keep_nodes, **kwargs)
         assert pruned_ts.num_nodes == len(
             keep_nodes
         )  # make sure we have right number of nodes

--- a/tests/test_regularize.py
+++ b/tests/test_regularize.py
@@ -29,6 +29,42 @@ class TestTimeRegularize(unittest.TestCase):
 
 
 class TestFrequencyRegularize(unittest.TestCase):
+    def test_samples(self):
+        """
+        Test that we can't pass samples to frequency_regularize()
+        """
+        ts = msprime.simulate(
+            100,
+            mutation_rate=1e-8,
+            random_seed=13,
+            recombination_rate=1e-8,
+            record_full_arg=False,
+            length=1e4,
+            Ne=10000,
+        )
+        freq = 0.2
+        with pytest.raises(ValueError):
+            ld_graph.frequency_regularize(ts, freq, **{"samples": [0, 1]})
+
+    def test_frequency_kwargs(self):
+        """
+        Test we can pass kwargs to frequency regularise
+        """
+        ts = msprime.simulate(
+            100,
+            mutation_rate=1e-8,
+            random_seed=13,
+            recombination_rate=1e-8,
+            record_full_arg=False,
+            length=1e4,
+            Ne=10000,
+        )
+        freq = 0.2
+        regularized = ld_graph.frequency_regularize(ts, freq, **{"filter_sites": False})
+        assert ts.num_sites == regularized.num_sites
+        regularized = ld_graph.frequency_regularize(ts, freq, **{"filter_sites": True})
+        assert ts.num_sites != regularized.num_sites
+
     @pytest.mark.skip(
         "Need to figure out how to get mapping to original node"
         "id/frequency to test this"


### PR DESCRIPTION
Adds the option to pass `kwargs` to `ld_graph.frequency_regularize()` which are then passed to `simplify()`. This way we can keep track of which sites are removed.