### PR TITLE
New approach: two step brickgraph and snp-haplo graphs

### DIFF
--- a/ld_graph/brickgraph.py
+++ b/ld_graph/brickgraph.py
@@ -12,13 +12,18 @@ from . import utility
 
 class BrickGraph:
     """
-    Each brick has six nodes:
+    Each brick has five nodes:
     0: up before
     1: up after
     2: down before
     3: down after
-    4: in
-    5: out
+    4: out
+    5: haplo before
+    6: haplo after
+    7: [empty]
+
+    So to find nodes for a brick or haplotype:
+    brick/haplo_index * 8 + desired_node_type_id
     """
 
     def __init__(self, bricked_ts, threshold, progress=True):
@@ -47,46 +52,55 @@ class BrickGraph:
         else:
             self.brick_graph.add_edge(from_node, to_node, weight=weight)
 
-    def vertex(self, edge_id, down, after, out):
-        vertex_id = 6 * edge_id
-        if edge_id in self.labeled_bricks:
-            if out:
-                vertex_id += 1
-            return vertex_id + 4
+    def vertex(self, identifier, down, after, out, haplo):
+        """
+        Function to convert haplo/brick ID to desired vertex id.
+        identifier is the haplotype (node) or brick id from the tree sequence.
+        Down is a bool, if true, refer to the down vertex.
+        After is a bool, referring to after vertex
+        Out indicates out vertex of labeled brick
+        Haplo indicates if identifier refers to a haplotype
+        """
+        vertex_id = 8 * identifier
+        if out:
+            if identifier in self.labeled_bricks:
+                return vertex_id + 4
         if down:
             vertex_id += 2
+            if haplo:
+                raise ValueError("Haplos cannot be down")
         if after:
             vertex_id += 1
+        if haplo:
+            vertex_id += 5
         return vertex_id
 
     def connect_vertices(
         self,
-        edge_id_a,
-        edge_id_b,
+        id_a,
+        id_b,
         child=None,
+        out=False,
         down_a=False,
         down_b=False,
         after_a=False,
         after_b=False,
+        haplo=False,
         reverse_odds=False,
-        combine_odds="division",
+        combine_odds="rule_one",
     ):
         """
         Up and before are default for both verticies
         """
-        vertex_a = self.vertex(edge_id_a, out=True, after=after_a, down=down_a)
-        vertex_b = self.vertex(edge_id_b, out=False, after=after_b, down=down_b)
-        odds_a = self.find_odds(edge_id_a)
-        odds_b = self.find_odds(edge_id_b)
-        if reverse_odds:
-            odds_c = odds_a
-            odds_a = odds_b
-            odds_b = odds_c
-        if combine_odds == "division":
+        vertex_a = self.vertex(id_a, out=out, after=after_a, down=down_a, haplo=False)
+        vertex_b = self.vertex(id_b, out=False, after=after_b, down=down_b, haplo=haplo)
+        odds_a = self.find_odds(id_a)
+        odds_b = self.find_odds(id_b)
+        if combine_odds == "rule_one":
             weight = self.log_odds(odds_a / odds_b)
-        elif combine_odds == "multiply":
+        elif combine_odds == "rule_two":
             weight = self.log_odds(odds_a * odds_b)
-        elif combine_odds == "self":
+        elif combine_odds == "haplo":
             weight = self.log_odds(1)
         else:
             raise ValueError("Incorrect combine_odds method")
@@ -98,131 +112,111 @@ class BrickGraph:
         Connect focal brick (indexed by edge.child) to its child bricks
         """
         focal_node = edge.child
-        for child in children:
-            assert self.node_edge_dict[child] != self.node_edge_dict[focal_node]
-            # Up before of child to up before of parent
-            self.connect_vertices(
-                self.node_edge_dict[child], self.node_edge_dict[focal_node]
-            )
+
+        def do_rule_one(parent, child):
+            labeled_parent = parent in self.labeled_bricks
+            labeled_child = child in self.labeled_bricks
+            assert self.node_edge_dict[child] != self.node_edge_dict[parent]
 
             # Up after of child to up after of parent
             self.connect_vertices(
                 self.node_edge_dict[child],
-                self.node_edge_dict[focal_node],
+                self.node_edge_dict[parent],
                 after_a=True,
                 after_b=True,
-            )
-
-            # Down before of parent to down before of child
-            self.connect_vertices(
-                self.node_edge_dict[focal_node],
-                self.node_edge_dict[child],
-                down_a=True,
-                down_b=True,
-                reverse_odds=True,
             )
 
             # Down after of parent to down after of child
             self.connect_vertices(
-                self.node_edge_dict[focal_node],
+                self.node_edge_dict[parent],
                 self.node_edge_dict[child],
                 after_a=True,
                 after_b=True,
                 down_a=True,
                 down_b=True,
-                reverse_odds=True,
             )
+
+            # Up before of child to EITHER up before of parent (if child is unlabeled)
+            # or up after of parent (if child is labeled)
+            self.connect_vertices(
+                self.node_edge_dict[child],
+                self.node_edge_dict[parent],
+                after_b=labeled_child,
+            )
+
+            # Down before of parent to EITHER down before of child
+            # (if parent is unlabeled) or down after of child (if parent is labeled)
+            self.connect_vertices(
+                self.node_edge_dict[parent],
+                self.node_edge_dict[child],
+                down_a=True,
+                down_b=True,
+                after_b=labeled_parent,
+            )
+
+            # If parent brick is labeled, make out connections
+            if labeled_parent:
+                # Out of parent to down before of child
+                self.connect_vertices(
+                    self.node_edge_dict[parent],
+                    self.node_edge_dict[child],
+                    out=True,
+                    down_b=True,
+                )
+            if labeled_child:
+                # do out of child to up before of parent
+                self.connect_vertices(
+                    self.node_edge_dict[child],
+                    self.node_edge_dict[parent],
+                    out=True,
+                )
+
+        for child in children:
+            do_rule_one(focal_node, child)
 
         # Connect focal brick to its parent brick, making same connections as above
         if edge.parent not in roots and focal_node not in roots:
             assert self.node_edge_dict[focal_node] != self.node_edge_dict[edge.parent]
-            self.connect_vertices(
-                self.node_edge_dict[focal_node], self.node_edge_dict[edge.parent]
-            )
-            self.connect_vertices(
-                self.node_edge_dict[focal_node],
-                self.node_edge_dict[edge.parent],
-                after_a=True,
-                after_b=True,
-            )
-            self.connect_vertices(
-                self.node_edge_dict[edge.parent],
-                self.node_edge_dict[focal_node],
-                down_a=True,
-                down_b=True,
-                reverse_odds=True,
-            )
-            self.connect_vertices(
-                self.node_edge_dict[edge.parent],
-                self.node_edge_dict[focal_node],
-                after_a=True,
-                after_b=True,
-                down_a=True,
-                down_b=True,
-                reverse_odds=True,
-            )
+            do_rule_one(edge.parent, focal_node)
 
     def rule_two(self, edge, siblings):
         # Rule 2: Connect focal brick to its siblings
         if len(siblings) > 1:
-            for pair in itertools.combinations(siblings, 2):
-                # Up before left to down before right
-                self.connect_vertices(
-                    self.node_edge_dict[pair[0]],
-                    self.node_edge_dict[pair[1]],
-                    down_b=True,
-                    combine_odds="multiply",
-                )
-                # Up before right to down before left
-                self.connect_vertices(
-                    self.node_edge_dict[pair[1]],
-                    self.node_edge_dict[pair[0]],
-                    down_b=True,
-                    combine_odds="multiply",
-                )
-                # Up after left to down after right
-                self.connect_vertices(
-                    self.node_edge_dict[pair[0]],
-                    self.node_edge_dict[pair[1]],
-                    after_a=True,
-                    after_b=True,
-                    down_b=True,
-                    combine_odds="multiply",
-                )
-                # Up after right to down after left
-                self.connect_vertices(
-                    self.node_edge_dict[pair[1]],
-                    self.node_edge_dict[pair[0]],
-                    after_a=True,
-                    after_b=True,
-                    down_b=True,
-                    combine_odds="multiply",
-                )
+            for pair_combo in itertools.combinations(siblings, 2):
+                for pair in (
+                    (pair_combo[0], pair_combo[1]),
+                    (pair_combo[1], pair_combo[0]),
+                ):
+                    assert pair[0] != pair[1]
+                    labeled_0 = pair[0] in self.labeled_bricks
+                    # Up after left to down after right
+                    self.connect_vertices(
+                        self.node_edge_dict[pair[0]],
+                        self.node_edge_dict[pair[1]],
+                        after_a=True,
+                        after_b=True,
+                        down_b=True,
+                        combine_odds="rule_two",
+                    )
 
-    def rule_three(self, edges, child):
-        """
-        Connect left before down to right after up and right before down to left after up
-        """
-        if len(edges) > 1:
-            for pair in itertools.combinations(edges, 2):
-                # Down before left to up after right
-                self.connect_vertices(
-                    pair[0],
-                    pair[1],
-                    child=child,
-                    down_a=True,
-                    after_b=True,
-                    combine_odds="self",
-                )
-                # Down before right to up after left
-                self.connect_vertices(
-                    pair[1],
-                    pair[0],
-                    child=child,
-                    down_a=True,
-                    after_a=True,
-                    combine_odds="self",
-                )
+                    # Up before left to down before right
+                    self.connect_vertices(
+                        self.node_edge_dict[pair[0]],
+                        self.node_edge_dict[pair[1]],
+                        down_b=True,
+                        after_b=labeled_0,
+                        combine_odds="rule_two",
+                    )
+
+                    # If brick 0 in sibling pair is labeled, make out connections
+                    if labeled_0:
+                        # Out to down before
+                        self.connect_vertices(
+                            self.node_edge_dict[pair[0]],
+                            self.node_edge_dict[pair[1]],
+                            out=True,
+                            down_b=True,
+                        )
 
     def make_connections(self, edge, tree2, index):
         roots = tree2.roots
@@ -238,9 +232,9 @@ class BrickGraph:
     def make_brick_graph(self):
         """
         Given a "bricked" ts, connect bricks according to three rules:
+        0. Connect each brick to its child haplotype
         1. Connect parent and child bricks
         2. Connect sibling bricks
-        3. Connect bricks which have two different adjacent parents
         """
         bricks_to_muts = utility.get_mut_edges(self.bricked_ts)
         self.labeled_bricks = np.array(list(bricks_to_muts.keys()))
@@ -262,15 +256,39 @@ class BrickGraph:
         self.node_edge_dict = {}
 
         # Rule Zero
-        # For unlabeled nodes: connect down before to up after (within a brick)
-        for brick in self.unlabeled_bricks:
+        # Connect each brick to its child haplotype
+        for brick in self.bricked_ts.edges():
+            labeled_brick = brick.id in self.labeled_bricks
+            # If brick is labeled: down before to after of child haplotype
+            # Else if brick is unlabeled, down before of brick to before
+            # of child haplotype
             self.connect_vertices(
-                brick,
-                brick,
+                brick.id,
+                brick.child,
                 down_a=True,
-                after_b=True,
-                combine_odds="self",
+                after_b=labeled_brick,
+                haplo=True,
+                combine_odds="haplo",
             )
+            # Down after of brick to after of child haplotype
+            self.connect_vertices(
+                brick.id,
+                brick.child,
+                down_a=True,
+                after_a=True,
+                after_b=True,
+                haplo=True,
+                combine_odds="haplo",
+            )
+            if labeled_brick:
+                # Out of brick to before of child haplotype
+                self.connect_vertices(
+                    brick.id,
+                    brick.child,
+                    out=True,
+                    haplo=True,
+                    combine_odds="haplo",
+                )
 
         for index, (tree2, (_, edges_out, edges_in)) in tqdm(
             enumerate(zip(self.bricked_ts.trees(), self.bricked_ts.edge_diffs())),
@@ -287,4 +305,9 @@ class BrickGraph:
             for edge in edges_in:
                 self.make_connections(edge, tree2, index)
 
+        # Sanity checks
+        # No connections from a haplotype vertex pointing outwards
+        # TODO check vertices 5 and 6 never start an edge
+        # Vertex 7 is never used
+        # Out is never second position in an edge
         return self.brick_graph

--- a/ld_graph/core.py
+++ b/ld_graph/core.py
@@ -15,21 +15,25 @@ def brick_ts(ts, threshold, add_dummy_bricks=False, progress=True):
     return bricked
 
 
-def brick_graph(brick_ts, threshold=None, progress=True):
+def brick_graph(brick_ts, threshold=None, use_rule_two=False, progress=True):
     """
     Make a brick graph
     """
-    brick_grapher = brickgraph.BrickGraph(brick_ts, threshold, progress=progress)
+    brick_grapher = brickgraph.BrickGraph(
+        brick_ts, threshold, use_rule_two=use_rule_two, progress=progress
+    )
     bricked_graph = brick_grapher.make_brick_graph()
     return bricked_graph
 
 
-def reduce_graph(brick_graph, brick_ts, threshold, progress=True):
+def reduce_graph(
+    brick_graph, brick_ts, threshold, make_snp_snp_edges=True, progress=True
+):
     """
     Make a reduced graph from a brick graph and bricked tree sequence
     """
     snp_grapher = reduction.SNP_Graph(
-        brick_graph, brick_ts, threshold, progress=progress
+        brick_graph, brick_ts, threshold, make_snp_snp_edges, progress=progress
     )
     reduced_graph = snp_grapher.create_reduced_graph()
     return reduced_graph


### PR DESCRIPTION
New approach, where we run the brickgraph creation in two steps (rule one and rule two), create reach * sets, and perform a graph reduction. Works on the small example we use in the paper.